### PR TITLE
Updates to label drawing in point/line charts

### DIFF
--- a/Sources/Microcharts/ChartEntry.cs
+++ b/Sources/Microcharts/ChartEntry.cs
@@ -61,6 +61,18 @@ namespace Microcharts
         /// <value>The color of the value label.</value>
         public SKColor ValueLabelColor { get; set; } = SKColors.Black;
 
+        /// <summary>
+        /// Determines if the label for the value is truncated to fit the width of the bar, point or line in the chart.
+        /// Defaults to true.
+        /// </summary>
+        public bool ValueLabelFitToBar { get; set; } = true;
+
+        /// <summary>
+        /// Determines the vertical position for the value's label, in relation to the bar, point or line in the chart.
+        /// Defaults to appearing above the bar (UpToElementHeight).
+        /// </summary>
+        public YPositionBehavior? ValueLabelYPositionBehavior { get; set; }
+
         #endregion
     }
 }

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -251,8 +251,12 @@ namespace Microcharts
         /// <param name="itemX"></param>
         protected virtual void DrawValueLabel(SKCanvas canvas, Dictionary<ChartEntry, SKRect> valueLabelSizes, float headerWithLegendHeight, SKSize itemSize, SKSize barSize, ChartEntry entry, float barX, float barY, float itemX, float origin)
         {
-            if (!string.IsNullOrEmpty(entry?.ValueLabel))
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, YPositionBehavior.UpToElementHeight, barSize, new SKPoint(barX - (itemSize.Width / 2) + (barSize.Width / 2), headerWithLegendHeight - Margin), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+            if(string.IsNullOrEmpty(entry?.ValueLabel))
+            {
+                return;
+            }
+
+            DrawHelper.DrawLabel(canvas, ValueLabelOrientation, YPositionBehavior.UpToElementHeight, barSize, new SKPoint(barX - (itemSize.Width / 2) + (barSize.Width / 2), headerWithLegendHeight - Margin), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
         }
 
         /// <summary>
@@ -288,7 +292,7 @@ namespace Microcharts
             {
                 var serie = series[i];
                 var serieBound = seriesNameSize[i];
-            
+
                 float legentItemWidth = Margin + SerieLabelTextSize + Margin + serieBound.Width;
                 if (legentItemWidth > width)
                 {

--- a/Sources/Microcharts/Charts/BarChart.cs
+++ b/Sources/Microcharts/Charts/BarChart.cs
@@ -61,11 +61,11 @@ namespace Microcharts
 
             (SKPoint location, SKSize size) = GetBarDrawingProperties(headerWithLegendHeight, itemSize, barSize, 0, barX, barY);
             if(ValueLabelOption == ValueLabelOption.TopOfChart)
-                base.DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
+                base.DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, entry.ValueLabelFitToBar ? barSize : SKSize.Empty, entry, barX, barY, itemX, origin);
             else if(ValueLabelOption == ValueLabelOption.TopOfElement)
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, barSize, new SKPoint(location.X + size.Width / 2, barY - Margin), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, entry.ValueLabelFitToBar ? barSize : SKSize.Empty, new SKPoint(location.X + size.Width / 2, barY - Margin), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
             else if(ValueLabelOption == ValueLabelOption.OverElement)
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementMiddle : YPositionBehavior.DownToElementMiddle, barSize, new SKPoint(location.X + size.Width / 2, barY + (origin - barY) / 2), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementMiddle : YPositionBehavior.DownToElementMiddle, entry.ValueLabelFitToBar ? barSize : SKSize.Empty, new SKPoint(location.X + size.Width / 2, barY + (origin - barY) / 2), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
         }
 
         /// <inheritdoc />

--- a/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
+++ b/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
@@ -272,7 +272,7 @@ namespace Microcharts
                     var entry = Entries.ElementAt(i);
                     if (!string.IsNullOrEmpty(entry.ValueLabel))
                     {
-                        DrawHelper.DrawLabel(canvas, orientation, isTop ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, itemSize, points[i], colors[i], sizes[i], texts[i], LabelTextSize, Typeface);
+                        DrawHelper.DrawLabel(canvas, orientation, isTop ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, entry.ValueLabelFitToBar ? itemSize : SKSize.Empty, points[i], colors[i], sizes[i], texts[i], LabelTextSize, Typeface);
                     }
                 }
             }

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -142,7 +142,7 @@ namespace Microcharts
 
                           }
 
-                          DrawHelper.DrawLabel(canvas, ValueLabelOrientation, yPositionBehavior, itemSize, point, entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSize, entry.ValueLabel, ValueLabelTextSize, Typeface);
+                          DrawHelper.DrawLabel(canvas, ValueLabelOrientation, DrawHelper.ComputeEntryYPositionBehavior(entry, yPositionBehavior), entry.ValueLabelFitToBar ? itemSize : SKSize.Empty, point, entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSize, entry.ValueLabel, ValueLabelTextSize, Typeface);
                         }
                     }
                 }

--- a/Sources/Microcharts/Charts/PointChart.cs
+++ b/Sources/Microcharts/Charts/PointChart.cs
@@ -54,11 +54,17 @@ namespace Microcharts
 
             var drawedPoint = new SKPoint(barX - (itemSize.Width / 2) + (barSize.Width / 2), barY);
             if (ValueLabelOption == ValueLabelOption.TopOfChart)
-                base.DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
-            else if (ValueLabelOption == ValueLabelOption.TopOfElement)
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, barSize, new SKPoint(drawedPoint.X, drawedPoint.Y - (PointSize / 2) - (Margin / 2)), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+                base.DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, entry.ValueLabelFitToBar ? barSize : SKSize.Empty, entry, barX, barY, itemX, origin);
+            else if(ValueLabelOption == ValueLabelOption.TopOfElement)
+            {
+                var behavior = ValueLabelOrientation == Orientation.Vertical
+                    ? YPositionBehavior.UpToElementHeight
+                    : YPositionBehavior.None;
+
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, behavior, entry.ValueLabelFitToBar ? barSize : SKSize.Empty, new SKPoint(drawedPoint.X, drawedPoint.Y - (PointSize / 2) - (Margin / 2)), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+            }
             else if (ValueLabelOption == ValueLabelOption.OverElement)
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementMiddle : YPositionBehavior.DownToElementMiddle, barSize, new SKPoint(drawedPoint.X, drawedPoint.Y), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementMiddle : YPositionBehavior.DownToElementMiddle, entry.ValueLabelFitToBar ? barSize : SKSize.Empty, new SKPoint(drawedPoint.X, drawedPoint.Y), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
         }
 
         /// <inheritdoc />

--- a/Sources/Microcharts/Helpers/DrawHelper.cs
+++ b/Sources/Microcharts/Helpers/DrawHelper.cs
@@ -6,18 +6,42 @@ using SkiaSharp;
 
 namespace Microcharts
 {
-    internal enum YPositionBehavior
+    /// <summary>
+    /// Represents the vertical position of value labels.
+    /// </summary>
+    public enum YPositionBehavior
     {
+        /// <summary>
+        /// Do not show the label at all.
+        /// </summary>
         None,
+        /// <summary>
+        /// Show the label above the element.
+        /// </summary>
         UpToElementHeight,
+        /// <summary>
+        /// Show the label above the middle point of the element.
+        /// </summary>
         UpToElementMiddle,
-        DownToElementMiddle
+        /// <summary>
+        /// Show the label below the middle point of the element.
+        /// </summary>
+        DownToElementMiddle,
+        /// <summary>
+        /// Show the label below the element.
+        /// </summary>
+        DownToElementHeight
     }
 
     internal static class DrawHelper
     {
-        
-        internal static void DrawLabel(SKCanvas canvas, Orientation orientation, YPositionBehavior yPositionBehavior, SKSize itemSize, SKPoint point, SKColor color, SKRect bounds, string text, float textSize, SKTypeface typeface)
+        internal static YPositionBehavior ComputeEntryYPositionBehavior(
+            ChartEntry entry, YPositionBehavior defaultBehaviour)
+        {
+            return entry.ValueLabelYPositionBehavior.GetValueOrDefault(defaultBehaviour);
+        }
+
+        internal static void DrawLabel(SKCanvas canvas, Orientation orientation, YPositionBehavior yPositionBehavior, SKSize itemSize, SKPoint point, SKColor color, SKRect bounds, string text, float textSize, SKTypeface typeface, bool belowPoint = false)
         {
             using (new SKAutoCanvasRestore(canvas))
             {
@@ -44,26 +68,32 @@ namespace Microcharts
                             case YPositionBehavior.DownToElementMiddle:
                                 y += bounds.Width / 2;
                                 break;
-                            case YPositionBehavior.None:
-                            default:
+                            case YPositionBehavior.DownToElementHeight:
+                                y += bounds.Width * 2;
                                 break;
                         }
+
+                        // TODO: this needs to clamp to inside the control (top/bottom edges)
 
                         canvas.RotateDegrees(90);
                         canvas.Translate(y, -point.X + (bounds.Height / 2));
                     }
                     else
                     {
-                        if (bounds.Width > itemSize.Width)
+                        // if no passed in size of the element we are drawing a label against, skip truncating the label
+                        if(!itemSize.IsEmpty)
                         {
-                            text = text.Substring(0, Math.Min(3, text.Length));
-                            paint.MeasureText(text, ref bounds);
-                        }
+                            if (bounds.Width > itemSize.Width)
+                            {
+                                text = text.Substring(0, Math.Min(3, text.Length));
+                                paint.MeasureText(text, ref bounds);
+                            }
 
-                        if (bounds.Width > itemSize.Width)
-                        {
-                            text = text.Substring(0, Math.Min(1, text.Length));
-                            paint.MeasureText(text, ref bounds);
+                            if (bounds.Width > itemSize.Width)
+                            {
+                                text = text.Substring(0, Math.Min(1, text.Length));
+                                paint.MeasureText(text, ref bounds);
+                            }
                         }
 
                         var y = point.Y;
@@ -79,12 +109,19 @@ namespace Microcharts
                             case YPositionBehavior.DownToElementMiddle:
                                 y += bounds.Height / 2;
                                 break;
-                            case YPositionBehavior.None:
-                            default:
+                            case YPositionBehavior.DownToElementHeight:
+                                y += bounds.Height * 2;
                                 break;
                         }
 
-                        canvas.Translate(point.X - (bounds.Width / 2), y);
+                        // clamp to inside the control (left/right edges)
+                        var x = point.X - bounds.Width / 2;
+                        if(x < 0)
+                            x = 0;
+                        if(x > canvas.LocalClipBounds.Width - bounds.Width)
+                            x = canvas.LocalClipBounds.Width - bounds.Width;
+
+                        canvas.Translate(x, y);
                     }
 
                     canvas.DrawText(text, 0, 0, paint);


### PR DESCRIPTION
This does a few things:

* Adds the ability to not clip the value label. In the original code when using a `LineChart`, if the `ValueLabel` text was wider than the point on the graph, the text would be truncated to one or two characters, depending on the width of the point. This now includes an option, at `ChartEntry` level, to set this on a per-entry basis via the `ValueLabelFitToBar` property.
* Adds the ability to position a value label below the point, as opposed to above and in the middle. This can be set on `ChartEntry` items using the `ValueLabelYPositionBehavior` property, using the new `DownToElementHeight` option.
* Clamps horizontal labels to edge of canvas, so they don't clip off the chart (useful when `ValueLabelFitToBar` is false).

